### PR TITLE
Allow plugin to run under Craft 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "codemonauts/craft-readonly-field",
   "description": "Craft CMS plugin to add a simple, read-only plaintext field.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "type": "craft-plugin",
   "keywords": [
     "craft",
@@ -24,7 +24,7 @@
     "issues": "https://github.com/codemonauts/craft-readonly-field/issues"
   },
   "require": {
-    "craftcms/cms": "^4.0.0 || ^5.0.0"
+    "craftcms/cms": "^4.0.0|^5.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,15 @@
     "issues": "https://github.com/codemonauts/craft-readonly-field/issues"
   },
   "require": {
-    "craftcms/cms": "^4.0.0"
+    "craftcms/cms": "^4.0.0 || ^5.0.0"
   },
   "autoload": {
     "psr-4": {
       "codemonauts\\readonly\\": "src/"
     }
+  },
+  "archive": {
+    "exclude": ["vendor", "*.tar"]
   },
   "extra": {
     "handle": "readonly",


### PR DESCRIPTION
The plugin seems to work just fine with Craft 5 in one of our applications.

Currently we have it installed as File with the following changes in our project composer.json:
```
"repositories": [
  ...
  {
      "type": "package",
      "package": {
        "name": "codemonauts/craft-readonly-field",
        "version": "2.1.0",
        "dist": {
          "url": "/opt/libraries/php/codemonauts-craft-readonly-field-2.1.0.tar",
          "type": "tar"
        },
        "type": "craft-plugin",
        "autoload": {
          "psr-4": {
            "codemonauts\\readonly\\": "src/"
          }
        },
        "extra": {
          "name": "Read-only Field",
          "handle": "readonly",
          "class": "codemonauts\\readonly\\ReadonlyPlugin"
        }
      }
    },
]
```

To allow php to find it we store the archived plugin in artifacts folder and map it into our docker container. docker-compose.yml:
```
   ...
    volumes:
      - ./artifacts:/opt/libraries/php
```
